### PR TITLE
Turns opaque to NO

### DIFF
--- a/Pod/Sources/Categories/UIImage+OriginateResize.m
+++ b/Pod/Sources/Categories/UIImage+OriginateResize.m
@@ -57,7 +57,7 @@
 {
     //Determine whether the screen is retina
     if ([[UIScreen mainScreen] scale] == 2.0) {
-        UIGraphicsBeginImageContextWithOptions(newSize, YES, 2.0);
+        UIGraphicsBeginImageContextWithOptions(newSize, NO, 2.0);
     }
     else
     {


### PR DESCRIPTION
This: ![screen shot 2015-09-30 at 1 52 06 pm](https://cloud.githubusercontent.com/assets/3579673/10206973/947f0010-677e-11e5-9b37-6e1567d3b5c3.png)

Becomes this:
![screen shot 2015-09-30 at 1 58 15 pm](https://cloud.githubusercontent.com/assets/3579673/10206976/9a533560-677e-11e5-8e49-3d93dcea746d.png)

When used this way:
`UIImage *newsletterIcon = [[UIImage imageNamed:@"newslettersIconEmptyState"] imageTintedWithColor:self.theme.emptyImageTintColor];`
`return [UIImage imageWithImage:newsletterIcon scaledToFillToSize:CGSizeMake(110, 125)];`
