### PR TITLE
Ss adjust view layout based on keyboard

### DIFF
--- a/Example/OriginateUI.xcodeproj/project.pbxproj
+++ b/Example/OriginateUI.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		95CBDA91BADD48F6A32D9C46 /* Pods_OriginateUI_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58AEF2D3E78B999ADBEEC5A /* Pods_OriginateUI_Example.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		F50EA1EEB52A916CDDEA245D /* Pods_OriginateUI_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C7122CBC1B9939C56CBBAFA /* Pods_OriginateUI_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		0949850F1CCE5DC90003A2B4 /* MyKeyboardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0949850D1CCE5DC90003A2B4 /* MyKeyboardViewController.m */; };
+		094985101CCE5DC90003A2B4 /* MyKeyboardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0949850E1CCE5DC90003A2B4 /* MyKeyboardViewController.xib */; };
+		95CBDA91BADD48F6A32D9C46 /* Pods_OriginateUI_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58AEF2D3E78B999ADBEEC5A /* Pods_OriginateUI_Example.framework */; };
+		F50EA1EEB52A916CDDEA245D /* Pods_OriginateUI_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C7122CBC1B9939C56CBBAFA /* Pods_OriginateUI_Tests.framework */; };
 		F96B54261BB18B9D004B884D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F96B54251BB18B9D004B884D /* main.m */; };
 		F96B54291BB18B9D004B884D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F96B54281BB18B9D004B884D /* AppDelegate.m */; };
 		F96B542C1BB18B9D004B884D /* MyThemableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F96B542B1BB18B9D004B884D /* MyThemableViewController.m */; };
@@ -31,6 +33,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0949850C1CCE5DC90003A2B4 /* MyKeyboardViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MyKeyboardViewController.h; sourceTree = "<group>"; };
+		0949850D1CCE5DC90003A2B4 /* MyKeyboardViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MyKeyboardViewController.m; sourceTree = "<group>"; };
+		0949850E1CCE5DC90003A2B4 /* MyKeyboardViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MyKeyboardViewController.xib; sourceTree = "<group>"; };
 		0FDE9AFAE30980A84076259B /* Pods-OriginateUI-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OriginateUI-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OriginateUI-Tests/Pods-OriginateUI-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		1C7122CBC1B9939C56CBBAFA /* Pods_OriginateUI_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OriginateUI_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8103B50BE03DC6E62E0F8D83 /* Pods-OriginateUI-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OriginateUI-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OriginateUI-Example/Pods-OriginateUI-Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -77,6 +82,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0949850B1CCE5D830003A2B4 /* Keyboard Examples */ = {
+			isa = PBXGroup;
+			children = (
+				0949850C1CCE5DC90003A2B4 /* MyKeyboardViewController.h */,
+				0949850D1CCE5DC90003A2B4 /* MyKeyboardViewController.m */,
+				0949850E1CCE5DC90003A2B4 /* MyKeyboardViewController.xib */,
+			);
+			name = "Keyboard Examples";
+			sourceTree = "<group>";
+		};
 		697A2F1476AD6A02C1017C63 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -140,6 +155,7 @@
 		F96B54221BB18B9D004B884D /* OriginateUI */ = {
 			isa = PBXGroup;
 			children = (
+				0949850B1CCE5D830003A2B4 /* Keyboard Examples */,
 				F96B54271BB18B9D004B884D /* AppDelegate.h */,
 				F96B54281BB18B9D004B884D /* AppDelegate.m */,
 				F96B542A1BB18B9D004B884D /* MyThemableViewController.h */,
@@ -260,6 +276,7 @@
 				F97A38EE1BB1C1D400E52ED4 /* StyleDefinition.json in Resources */,
 				F96B54341BB18B9D004B884D /* LaunchScreen.xib in Resources */,
 				F96B54311BB18B9D004B884D /* Images.xcassets in Resources */,
+				094985101CCE5DC90003A2B4 /* MyKeyboardViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,6 +388,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0949850F1CCE5DC90003A2B4 /* MyKeyboardViewController.m in Sources */,
 				F96B542C1BB18B9D004B884D /* MyThemableViewController.m in Sources */,
 				F97A38EC1BB1C12100E52ED4 /* MyTheme.m in Sources */,
 				F96B54291BB18B9D004B884D /* AppDelegate.m in Sources */,

--- a/Example/OriginateUI/MyKeyboardViewController.h
+++ b/Example/OriginateUI/MyKeyboardViewController.h
@@ -1,0 +1,14 @@
+//
+//  MyKeyboardViewController.h
+//  OriginateUI
+//
+//  Created by Shen on 4/25/16.
+//  Copyright © 2016 originate.com. All rights reserved.
+//
+
+@import UIKit;
+@import OriginateUI;
+
+@interface MyKeyboardViewController : UIViewController
+
+@end

--- a/Example/OriginateUI/MyKeyboardViewController.m
+++ b/Example/OriginateUI/MyKeyboardViewController.m
@@ -1,0 +1,119 @@
+//
+//  MyKeyboardViewController.m
+//  OriginateUI
+//
+//  Created by Shen on 4/25/16.
+//  Copyright © 2016 originate.com. All rights reserved.
+//
+
+#import "MyKeyboardViewController.h"
+
+@interface MyKeyboardViewController () <UITextFieldDelegate, UITextViewDelegate>
+
+@property (nonatomic) CGRect defaultViewFrame;
+@property (nonatomic) CGFloat keyboardHeight;
+@property (nonatomic) NSTimeInterval keyboardAnimationDuration;
+@property (nonatomic, weak) UIView* activeView;
+
+@property (nonatomic, weak) IBOutlet UITextField* firstTextField;
+@property (nonatomic, weak) IBOutlet UITextField* secondTextField;
+@property (nonatomic, weak) IBOutlet UITextField* ThirdTextField;
+@property (nonatomic, weak) IBOutlet UITextField* ForthTextField;
+@property (nonatomic, weak) IBOutlet UITextField* FifthTextField;
+@property (nonatomic, weak) IBOutlet UITextView* textView;
+
+@end
+
+@implementation MyKeyboardViewController
+
+#pragma mark - Life Cycle
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  [self setupDismissKeyboardOnTap];
+  [self registerKeyboardNotifications];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+  [super viewDidAppear:animated];
+  self.defaultViewFrame = self.view.frame;
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+  [super viewWillDisappear:animated];
+  [self dismissKeyboard];
+}
+
+- (void)dealloc {
+  [self unregisterKeyboardNotifications];
+}
+
+#pragma mark - Keyboard Notifications
+
+- (void)registerKeyboardNotifications {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(keyboardWillShow:)
+                                               name:UIKeyboardWillShowNotification
+                                             object:nil];
+  
+  
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(keyboardWillHide)
+                                               name:UIKeyboardWillHideNotification
+                                             object:nil];
+}
+
+- (void)unregisterKeyboardNotifications {
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:UIKeyboardWillShowNotification
+                                                object:nil];
+  
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:UIKeyboardWillHideNotification
+                                                object:nil];
+}
+
+#pragma mark - Keyboard Listeners
+
+- (void)keyboardWillShow:(NSNotification*)notification {
+  self.keyboardHeight = [self defaultKeyboardHeightFromNotification:notification];
+  self.keyboardAnimationDuration = [self defaultKeyboardAnimationDurationFromNotification:notification];
+  
+  [self adjustLayoutWithActiveView:self.activeView keyboardHeight:self.keyboardHeight animationDuration:self.keyboardAnimationDuration defaultViewFrame:self.defaultViewFrame];
+}
+
+- (void)keyboardWillHide {
+  self.activeView = nil;
+  [self resetLayoutWithDefaultViewFrame:self.defaultViewFrame animationDuration:self.keyboardAnimationDuration];
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (void)textFieldDidBeginEditing:(UITextField*)textField {
+  self.activeView = textField;
+  [self adjustLayoutWithActiveView:self.activeView keyboardHeight:self.keyboardHeight animationDuration:self.keyboardAnimationDuration defaultViewFrame:self.defaultViewFrame];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField*)textField {
+  if (textField == self.FifthTextField) {
+    [self.ForthTextField becomeFirstResponder];
+  } else if (textField == self.ForthTextField) {
+    [self.ThirdTextField becomeFirstResponder];
+  } else if (textField == self.ThirdTextField) {
+    [self.secondTextField becomeFirstResponder];
+  } else if (textField == self.secondTextField) {
+    [self.textView becomeFirstResponder];
+  } else {
+    [textField resignFirstResponder];
+  }
+  return YES;
+}
+
+#pragma mark - UITextViewDelegate
+
+- (void)textViewDidBeginEditing:(UITextView*)textView {
+  self.activeView = textView;
+  [self adjustLayoutWithActiveView:self.activeView keyboardHeight:self.keyboardHeight animationDuration:self.keyboardAnimationDuration defaultViewFrame:self.defaultViewFrame];
+}
+
+@end

--- a/Example/OriginateUI/MyKeyboardViewController.xib
+++ b/Example/OriginateUI/MyKeyboardViewController.xib
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MyKeyboardViewController">
+            <connections>
+                <outlet property="FifthTextField" destination="Rvx-Zp-7S8" id="Zm0-QO-BCs"/>
+                <outlet property="ForthTextField" destination="Kbu-uC-XQK" id="1xs-YV-HXk"/>
+                <outlet property="ThirdTextField" destination="ydE-9W-aDP" id="b1g-c3-6MN"/>
+                <outlet property="firstTextField" destination="Wn4-X0-DSk" id="2bR-wQ-oHf"/>
+                <outlet property="secondTextField" destination="ZSC-XI-6GA" id="i7X-QM-IIe"/>
+                <outlet property="textView" destination="7dC-pf-Srd" id="8SM-pD-TbD"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wmu-ya-0Db">
+                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5QI-DH-m2T" userLabel="ContentView">
+                            <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                            <subviews>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Wn4-X0-DSk" userLabel="FirstTextField">
+                                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="-1" id="4bG-2p-rQN"/>
+                                    </connections>
+                                </textField>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZSC-XI-6GA" userLabel="SecondTextField">
+                                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" returnKeyType="next"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="-1" id="FzO-k5-Sew"/>
+                                    </connections>
+                                </textField>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ydE-9W-aDP" userLabel="ThirdTextField">
+                                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" returnKeyType="next"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="-1" id="JnA-r1-9QS"/>
+                                    </connections>
+                                </textField>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kbu-uC-XQK" userLabel="ForthTextField">
+                                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" returnKeyType="next"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="-1" id="4wX-ma-aIr"/>
+                                    </connections>
+                                </textField>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Rvx-Zp-7S8" userLabel="FifthTextField">
+                                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" returnKeyType="next"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="-1" id="n2E-mT-btP"/>
+                                    </connections>
+                                </textField>
+                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="7dC-pf-Srd">
+                                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="48" id="Nr6-41-9dZ"/>
+                                    </constraints>
+                                    <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    <variation key="default">
+                                        <mask key="constraints">
+                                            <exclude reference="Nr6-41-9dZ"/>
+                                        </mask>
+                                    </variation>
+                                    <variation key="heightClass=regular-widthClass=compact">
+                                        <mask key="constraints">
+                                            <include reference="Nr6-41-9dZ"/>
+                                        </mask>
+                                    </variation>
+                                    <connections>
+                                        <outlet property="delegate" destination="-1" id="5vz-Tw-xNC"/>
+                                    </connections>
+                                </textView>
+                            </subviews>
+                            <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="ZSC-XI-6GA" firstAttribute="top" secondItem="ydE-9W-aDP" secondAttribute="bottom" constant="100" id="9l3-i1-XSM"/>
+                                <constraint firstAttribute="trailing" secondItem="Kbu-uC-XQK" secondAttribute="trailing" id="BFt-si-gqI"/>
+                                <constraint firstItem="ZSC-XI-6GA" firstAttribute="leading" secondItem="5QI-DH-m2T" secondAttribute="leading" id="MC4-QC-2p1"/>
+                                <constraint firstItem="Rvx-Zp-7S8" firstAttribute="top" secondItem="5QI-DH-m2T" secondAttribute="top" constant="200" id="Wqd-BH-slM"/>
+                                <constraint firstAttribute="trailing" secondItem="Wn4-X0-DSk" secondAttribute="trailing" id="dgk-I4-YaQ"/>
+                                <constraint firstAttribute="trailing" secondItem="ydE-9W-aDP" secondAttribute="trailing" id="e1b-od-dUb"/>
+                                <constraint firstAttribute="bottom" secondItem="Wn4-X0-DSk" secondAttribute="bottom" constant="100" id="hKB-vc-lqI"/>
+                                <constraint firstAttribute="trailing" secondItem="ZSC-XI-6GA" secondAttribute="trailing" id="hzw-ch-KTa"/>
+                                <constraint firstItem="Wn4-X0-DSk" firstAttribute="leading" secondItem="5QI-DH-m2T" secondAttribute="leading" id="lpC-x0-ohI"/>
+                                <constraint firstAttribute="trailing" secondItem="7dC-pf-Srd" secondAttribute="trailing" id="m3z-sz-MCq"/>
+                                <constraint firstItem="7dC-pf-Srd" firstAttribute="leading" secondItem="5QI-DH-m2T" secondAttribute="leading" id="mIk-2W-VQp"/>
+                                <constraint firstItem="ydE-9W-aDP" firstAttribute="leading" secondItem="5QI-DH-m2T" secondAttribute="leading" id="n4L-V0-x6o"/>
+                                <constraint firstItem="Kbu-uC-XQK" firstAttribute="top" secondItem="Rvx-Zp-7S8" secondAttribute="bottom" constant="100" id="nLt-f9-Iq9"/>
+                                <constraint firstItem="Wn4-X0-DSk" firstAttribute="top" secondItem="7dC-pf-Srd" secondAttribute="bottom" constant="100" id="pQr-aV-08z"/>
+                                <constraint firstItem="Kbu-uC-XQK" firstAttribute="leading" secondItem="5QI-DH-m2T" secondAttribute="leading" id="qOr-PM-qIx"/>
+                                <constraint firstItem="7dC-pf-Srd" firstAttribute="top" secondItem="ZSC-XI-6GA" secondAttribute="bottom" constant="100" id="sDV-l6-FdU"/>
+                                <constraint firstItem="ydE-9W-aDP" firstAttribute="top" secondItem="Kbu-uC-XQK" secondAttribute="bottom" constant="100" id="sah-Hu-ien"/>
+                                <constraint firstItem="Rvx-Zp-7S8" firstAttribute="leading" secondItem="5QI-DH-m2T" secondAttribute="leading" id="tKp-L0-fJo"/>
+                                <constraint firstAttribute="trailing" secondItem="Rvx-Zp-7S8" secondAttribute="trailing" id="xAs-RP-dXH"/>
+                            </constraints>
+                            <variation key="default">
+                                <mask key="subviews">
+                                    <exclude reference="Wn4-X0-DSk"/>
+                                    <exclude reference="ZSC-XI-6GA"/>
+                                    <exclude reference="ydE-9W-aDP"/>
+                                    <exclude reference="Kbu-uC-XQK"/>
+                                    <exclude reference="Rvx-Zp-7S8"/>
+                                    <exclude reference="7dC-pf-Srd"/>
+                                </mask>
+                                <mask key="constraints">
+                                    <exclude reference="Wqd-BH-slM"/>
+                                    <exclude reference="tKp-L0-fJo"/>
+                                    <exclude reference="xAs-RP-dXH"/>
+                                    <exclude reference="BFt-si-gqI"/>
+                                    <exclude reference="nLt-f9-Iq9"/>
+                                    <exclude reference="qOr-PM-qIx"/>
+                                    <exclude reference="e1b-od-dUb"/>
+                                    <exclude reference="n4L-V0-x6o"/>
+                                    <exclude reference="sah-Hu-ien"/>
+                                    <exclude reference="9l3-i1-XSM"/>
+                                    <exclude reference="MC4-QC-2p1"/>
+                                    <exclude reference="hzw-ch-KTa"/>
+                                    <exclude reference="m3z-sz-MCq"/>
+                                    <exclude reference="mIk-2W-VQp"/>
+                                    <exclude reference="sDV-l6-FdU"/>
+                                    <exclude reference="dgk-I4-YaQ"/>
+                                    <exclude reference="hKB-vc-lqI"/>
+                                    <exclude reference="lpC-x0-ohI"/>
+                                    <exclude reference="pQr-aV-08z"/>
+                                </mask>
+                            </variation>
+                            <variation key="heightClass=regular-widthClass=compact">
+                                <mask key="subviews">
+                                    <include reference="Wn4-X0-DSk"/>
+                                    <include reference="ZSC-XI-6GA"/>
+                                    <include reference="ydE-9W-aDP"/>
+                                    <include reference="Kbu-uC-XQK"/>
+                                    <include reference="Rvx-Zp-7S8"/>
+                                    <include reference="7dC-pf-Srd"/>
+                                </mask>
+                                <mask key="constraints">
+                                    <include reference="Wqd-BH-slM"/>
+                                    <include reference="tKp-L0-fJo"/>
+                                    <include reference="xAs-RP-dXH"/>
+                                    <include reference="BFt-si-gqI"/>
+                                    <include reference="nLt-f9-Iq9"/>
+                                    <include reference="qOr-PM-qIx"/>
+                                    <include reference="e1b-od-dUb"/>
+                                    <include reference="n4L-V0-x6o"/>
+                                    <include reference="sah-Hu-ien"/>
+                                    <include reference="9l3-i1-XSM"/>
+                                    <include reference="MC4-QC-2p1"/>
+                                    <include reference="hzw-ch-KTa"/>
+                                    <include reference="m3z-sz-MCq"/>
+                                    <include reference="mIk-2W-VQp"/>
+                                    <include reference="sDV-l6-FdU"/>
+                                    <include reference="dgk-I4-YaQ"/>
+                                    <include reference="hKB-vc-lqI"/>
+                                    <include reference="lpC-x0-ohI"/>
+                                    <include reference="pQr-aV-08z"/>
+                                </mask>
+                            </variation>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="5QI-DH-m2T" firstAttribute="leading" secondItem="wmu-ya-0Db" secondAttribute="leading" id="Eiw-78-ifo"/>
+                        <constraint firstAttribute="trailing" secondItem="5QI-DH-m2T" secondAttribute="trailing" id="UsE-qQ-xxv"/>
+                        <constraint firstItem="5QI-DH-m2T" firstAttribute="centerX" secondItem="wmu-ya-0Db" secondAttribute="centerX" id="WtA-oR-Gum"/>
+                        <constraint firstItem="5QI-DH-m2T" firstAttribute="top" secondItem="wmu-ya-0Db" secondAttribute="top" id="qL7-hL-JIj"/>
+                        <constraint firstAttribute="bottom" secondItem="5QI-DH-m2T" secondAttribute="bottom" id="wkk-sp-76X"/>
+                    </constraints>
+                    <variation key="default">
+                        <mask key="subviews">
+                            <exclude reference="5QI-DH-m2T"/>
+                        </mask>
+                        <mask key="constraints">
+                            <exclude reference="Eiw-78-ifo"/>
+                            <exclude reference="UsE-qQ-xxv"/>
+                            <exclude reference="WtA-oR-Gum"/>
+                            <exclude reference="qL7-hL-JIj"/>
+                            <exclude reference="wkk-sp-76X"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular-widthClass=compact">
+                        <mask key="subviews">
+                            <include reference="5QI-DH-m2T"/>
+                        </mask>
+                        <mask key="constraints">
+                            <include reference="Eiw-78-ifo"/>
+                            <include reference="UsE-qQ-xxv"/>
+                            <include reference="WtA-oR-Gum"/>
+                            <include reference="qL7-hL-JIj"/>
+                            <include reference="wkk-sp-76X"/>
+                        </mask>
+                    </variation>
+                </scrollView>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QIG-Cm-X5O" userLabel="SixthTextField">
+                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                    <connections>
+                        <outlet property="delegate" destination="-1" id="fhS-sm-D7n"/>
+                    </connections>
+                </textField>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nfo-10-4wS" userLabel="SeventhTextField">
+                    <rect key="frame" x="-25" y="-30" width="97" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                    <connections>
+                        <outlet property="delegate" destination="-1" id="mCY-C6-ioH"/>
+                    </connections>
+                </textField>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="QIG-Cm-X5O" firstAttribute="top" secondItem="nfo-10-4wS" secondAttribute="bottom" constant="200" id="4mv-6h-xgG"/>
+                <constraint firstItem="wmu-ya-0Db" firstAttribute="leading" secondItem="QIG-Cm-X5O" secondAttribute="trailing" id="Cml-eu-7Ix"/>
+                <constraint firstAttribute="bottom" secondItem="QIG-Cm-X5O" secondAttribute="bottom" constant="100" id="Cti-Oj-RqL"/>
+                <constraint firstItem="wmu-ya-0Db" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="K6l-ng-TwD"/>
+                <constraint firstItem="wmu-ya-0Db" firstAttribute="width" secondItem="i5M-Pr-FkT" secondAttribute="width" multiplier="0.5" id="RzO-Cv-Clc"/>
+                <constraint firstItem="5QI-DH-m2T" firstAttribute="width" secondItem="i5M-Pr-FkT" secondAttribute="width" multiplier="0.5" id="XvH-sB-jQM"/>
+                <constraint firstItem="QIG-Cm-X5O" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="YLu-Xr-BkB"/>
+                <constraint firstItem="wmu-ya-0Db" firstAttribute="leading" secondItem="nfo-10-4wS" secondAttribute="trailing" id="evx-46-4IO"/>
+                <constraint firstItem="nfo-10-4wS" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="f5L-o3-QiZ"/>
+                <constraint firstAttribute="bottom" secondItem="wmu-ya-0Db" secondAttribute="bottom" id="jfy-5Z-35W"/>
+                <constraint firstAttribute="trailing" secondItem="wmu-ya-0Db" secondAttribute="trailing" id="zre-Pz-JfQ"/>
+            </constraints>
+            <variation key="default">
+                <mask key="subviews">
+                    <exclude reference="wmu-ya-0Db"/>
+                    <exclude reference="QIG-Cm-X5O"/>
+                    <exclude reference="nfo-10-4wS"/>
+                </mask>
+                <mask key="constraints">
+                    <exclude reference="XvH-sB-jQM"/>
+                    <exclude reference="Cml-eu-7Ix"/>
+                    <exclude reference="K6l-ng-TwD"/>
+                    <exclude reference="RzO-Cv-Clc"/>
+                    <exclude reference="evx-46-4IO"/>
+                    <exclude reference="jfy-5Z-35W"/>
+                    <exclude reference="zre-Pz-JfQ"/>
+                    <exclude reference="f5L-o3-QiZ"/>
+                    <exclude reference="4mv-6h-xgG"/>
+                    <exclude reference="Cti-Oj-RqL"/>
+                    <exclude reference="YLu-Xr-BkB"/>
+                </mask>
+            </variation>
+            <variation key="heightClass=regular-widthClass=compact">
+                <mask key="subviews">
+                    <include reference="wmu-ya-0Db"/>
+                    <include reference="QIG-Cm-X5O"/>
+                    <include reference="nfo-10-4wS"/>
+                </mask>
+                <mask key="constraints">
+                    <include reference="XvH-sB-jQM"/>
+                    <include reference="Cml-eu-7Ix"/>
+                    <include reference="K6l-ng-TwD"/>
+                    <include reference="RzO-Cv-Clc"/>
+                    <include reference="evx-46-4IO"/>
+                    <include reference="jfy-5Z-35W"/>
+                    <include reference="zre-Pz-JfQ"/>
+                    <include reference="f5L-o3-QiZ"/>
+                    <include reference="4mv-6h-xgG"/>
+                    <include reference="Cti-Oj-RqL"/>
+                    <include reference="YLu-Xr-BkB"/>
+                </mask>
+            </variation>
+            <point key="canvasLocation" x="591" y="302"/>
+        </view>
+    </objects>
+</document>

--- a/Example/OriginateUI/MyThemableViewController.m
+++ b/Example/OriginateUI/MyThemableViewController.m
@@ -8,6 +8,7 @@
 
 #import "MyThemableViewController.h"
 #import "MyTheme.h"
+#import "MyKeyboardViewController.h"
 
 @interface MyThemableViewController ()
 
@@ -25,6 +26,9 @@
     [super viewDidLoad];
     
     self.view.backgroundColor = self.theme.rootViewBackgroundColor;
+  
+  UITapGestureRecognizer* tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tappedView)];
+  [self.view addGestureRecognizer:tapGestureRecognizer];
 }
 
 - (NSString *)title
@@ -43,6 +47,13 @@
     }
     
     return self;
+}
+
+#pragma mark - Gesture Recognizer
+
+- (void)tappedView {
+  MyKeyboardViewController* nextViewController = [[MyKeyboardViewController alloc] init];
+  [self.navigationController pushViewController:nextViewController animated:YES];
 }
 
 @end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - OriginateUI (0.0.1)
+  - OriginateUI (0.0.10)
 
 DEPENDENCIES:
   - OriginateUI (from `../`)
 
 EXTERNAL SOURCES:
   OriginateUI:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  OriginateUI: 0764d34bba07ea348f76b4f9ec08646fb949bea9
+  OriginateUI: b1b30b0ad17e06adcf50e368132128fa5180d50c
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0

--- a/Pod/Sources/Categories/UIViewController+OriginateKeyboardHelpers.h
+++ b/Pod/Sources/Categories/UIViewController+OriginateKeyboardHelpers.h
@@ -1,0 +1,21 @@
+//
+//  UIViewController+OriginateKeyboardHelpers.h
+//  TDP
+//
+//  Created by Sophie Shen on 04/25/16.
+//  Copyright (c) 2016 Originate. All rights reserved.
+//
+
+@import UIKit;
+
+@interface UIViewController (OriginateKeyboardHelpers)
+
+- (void)setupDismissKeyboardOnTap;
+- (void)dismissKeyboard;
+- (void)adjustLayoutWithActiveView:(UIView*)activeView keyboardHeight:(CGFloat)keyboardHeight animationDuration:(NSTimeInterval)duration defaultViewFrame:(CGRect)viewFrame;
+- (void)resetLayoutWithDefaultViewFrame:(CGRect)viewFrame animationDuration:(NSTimeInterval)duration;
+
+- (CGFloat)defaultKeyboardHeightFromNotification:(NSNotification*)notification;
+- (CGFloat)defaultKeyboardAnimationDurationFromNotification:(NSNotification*)notification;
+
+@end

--- a/Pod/Sources/Categories/UIViewController+OriginateKeyboardHelpers.m
+++ b/Pod/Sources/Categories/UIViewController+OriginateKeyboardHelpers.m
@@ -1,0 +1,85 @@
+//
+//  UIViewController+OriginateKeyboardHelpers.m
+//  TDP
+//
+//  Created by Sophie Shen on 04/25/16.
+//  Copyright (c) 2016 Originate. All rights reserved.
+//
+
+#import "UIViewController+OriginateKeyboardHelpers.h"
+
+@implementation UIViewController (TDPKeyboardHelpers)
+
+#pragma mark - Dismiss Keyboard On Tap
+
+- (void)setupDismissKeyboardOnTap {
+  UITapGestureRecognizer* tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+  [self.view addGestureRecognizer:tapGestureRecognizer];
+}
+
+- (void)dismissKeyboard {
+  [self.view endEditing:YES];
+}
+
+- (void)adjustLayoutWithActiveView:(UIView*)activeView keyboardHeight:(CGFloat)keyboardHeight animationDuration:(NSTimeInterval)duration defaultViewFrame:(CGRect)viewFrame{
+  if (!(activeView && keyboardHeight > 0 && duration > 0)) {
+    return;
+  }
+  
+  // top position of the keyboard
+  CGFloat keyboardTop = CGRectGetHeight(self.view.frame) - keyboardHeight;
+  
+  // bottom position of the keyboard
+  CGRect textFieldFrame = [self.view convertRect:activeView.frame fromView:activeView.superview] ;
+  CGFloat originalTextFieldBottom = textFieldFrame.origin.y + textFieldFrame.size.height;
+  CGFloat textFieldBottom = MIN(originalTextFieldBottom, viewFrame.size.height);
+  
+  // if the keyboard covers the selected text field, move the view up
+  if (keyboardTop < textFieldBottom) {
+    CGRect newFrame = viewFrame;
+    float verticalOffset = textFieldBottom - keyboardTop;
+    newFrame.origin.y -= verticalOffset;
+
+    // animate the layout with the same animation rates of the keyboard when it appears
+    [UIView animateWithDuration:duration animations:^{
+      self.view.frame = newFrame;
+      
+      if (originalTextFieldBottom - viewFrame.size.height > 0 && ![activeView isKindOfClass:[UITextField class]]) {
+        UIScrollView* scrollView = nil;
+        UIView* view = activeView.superview;
+        while (view != self.view) {
+          if ([view isKindOfClass:[UIScrollView class]]) {
+            scrollView = (UIScrollView*)view;
+            break;
+          }
+          view = view.superview;
+        }
+        
+        if (scrollView) {
+          CGPoint contentOffset = scrollView.contentOffset;
+          contentOffset.y += originalTextFieldBottom - viewFrame.size.height;
+          scrollView.contentOffset = contentOffset;
+        }
+      }
+    }];
+  }
+}
+
+- (void)resetLayoutWithDefaultViewFrame:(CGRect)viewFrame animationDuration:(NSTimeInterval)duration {
+  // animate the layout with the same animation rates of the keyboard when it disappears
+  [UIView animateWithDuration:duration animations:^{
+    self.view.frame = viewFrame;
+  }];
+}
+
+#pragma mark - Class Method
+
+- (CGFloat)defaultKeyboardHeightFromNotification:(NSNotification*)notification {
+  return [self.view convertRect:[notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil].size.height;
+}
+
+- (CGFloat)defaultKeyboardAnimationDurationFromNotification:(NSNotification*)notification {
+  return [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+}
+
+@end

--- a/Pod/Sources/OriginateUI.h
+++ b/Pod/Sources/OriginateUI.h
@@ -24,6 +24,7 @@
 #import "UITableViewcell+OriginateSeparators.h"
 #import "UIView+OriginateMotionInterpolation.h"
 #import "UIViewController+OriginateTabBarScroller.h"
+#import "UIViewController+OriginateKeyboardHelpers.h"
 
 #import "OriginateBaseTransitionAnimation.h"
 #import "OriginatePushBackTransitionAnimation.h"


### PR DESCRIPTION
@pkluz @jhb563 @aarondaub @vipulvpatil @allewun @wtachau 

Migrated the keyboard adjustment tool of TDP, which we found is pretty convenient to adjust the view layout based on keyboard. I added a `UIViewController` category `UIViewController+OriginateKeyboardHelpers`, which can adjust the layout of the view if a text field or text view starts/finishes editing. Specifically, the view is optionally adjusted so the text field is not blocked by the keyboard. For text view, the tool only works well if there're no more than one scroll view in the view hierarchy between the view controller's view and the editing text view. Otherwise, if the text view is within a few looped scroll views, the layout would not entirely unblock the text view.

The example is in `MyKeyboardViewController`, which is followed by the first page of the example via a tapping. In the example, I added textfields/textview to a scroll view and to the controller's view to show possible cases the tool can handle.

Please take a look! :)
